### PR TITLE
rc: load $home/lib/profile if it exists for 9.rc

### DIFF
--- a/bin/9.rc
+++ b/bin/9.rc
@@ -4,5 +4,7 @@ if(~ $#PLAN9 0)
 	PLAN9=/usr/local/plan9
 if(! ~ $path(1) $PLAN9/bin)
 	path=($PLAN9/bin $path)
+if(test -r $HOME/lib/profile)
+	. $HOME/lib/profile
 
 ~ $#* 0 || exec $*


### PR DESCRIPTION
When running `9.rc` make load `lib/profile` to make sure a reasonable plan9 env is present.