### PR TITLE
acme: 'soft tabs' support

### DIFF
--- a/man/man1/acme.1
+++ b/man/man1/acme.1
@@ -4,7 +4,7 @@ acme, win, awd \- interactive text windows
 .SH SYNOPSIS
 .B acme
 [
-.B -abr
+.B -aibr
 ]
 [
 .B -f
@@ -203,6 +203,14 @@ The option
 .B -a
 causes each window to start in
 autoindent mode.
+.PP
+When a window is in spaces indent mode
+and a tab character is typed,
+acme indents the line with spaces equal to the current
+tabstop for the window. The option
+.B -i
+causes each window to start in spaces indent
+mode.
 .SS "Directory context
 Each window's tag names a directory: explicitly if the window
 holds a directory; implicitly if it holds a regular file
@@ -382,15 +390,23 @@ This command is largely superseded by plumbing
 .IR plumb (7)).
 .TP
 .B Indent
-Set the autoindent mode according to the argument:
+Set the indent mode according to the argument:
 .B on
 and
 .B off
-set the mode for the current window;
+set the autoindent mode for the current window;
+.B tab
+and
+.B space
+set the indent character for the current window;
+.B TAB
+and
+.B SPACE
+set the indent character for all existing and future windows;
 .B ON
 and
 .B OFF
-set the mode for all existing and future windows.
+set the autoindent mode for all existing and future windows.
 .TP
 .B Kill
 Send a

--- a/src/cmd/acme/acme.c
+++ b/src/cmd/acme/acme.c
@@ -78,7 +78,7 @@ threadmain(int argc, char *argv[])
 		}
 		break;
 	case 'a':
-		globalautoindent = TRUE;
+		globalindent |= IndentAuto;
 		break;
 	case 'b':
 		bartflag = TRUE;
@@ -101,6 +101,9 @@ threadmain(int argc, char *argv[])
 		if(fontnames[1] == nil)
 			goto Usage;
 		break;
+	case 'i':
+		globalindent |= IndentSpaces;
+		break;
 	case 'l':
 		loadfile = ARGF();
 		if(loadfile == nil)
@@ -121,7 +124,7 @@ threadmain(int argc, char *argv[])
 		break;
 	default:
 	Usage:
-		fprint(2, "usage: acme -a -c ncol -f fontname -F fixedwidthfontname -l loadfile -W winsize\n");
+		fprint(2, "usage: acme -aibr -c ncol -f fontname -F fixedwidthfontname -l loadfile -W winsize\n");
 		threadexitsall("usage");
 	}ARGEND
 

--- a/src/cmd/acme/dat.h
+++ b/src/cmd/acme/dat.h
@@ -198,6 +198,13 @@ struct Text
 	int	needundo;
 };
 
+enum
+{
+  /* default is tab indent, i.e. b'0 */
+	IndentSpaces = 0x1,
+	IndentAuto   = 0x2
+};
+
 uint		textbacknl(Text*, uint, uint);
 uint		textbsinsert(Text*, uint, Rune*, uint, int, int*);
 int		textbswidth(Text*, Rune);
@@ -240,7 +247,7 @@ struct Window
 	uchar	isscratch;
 	uchar	filemenu;
 	uchar	dirty;
-	uchar	autoindent;
+	uchar	indent;
 	uchar	showdel;
 	int		id;
 	Range	addr;
@@ -552,7 +559,7 @@ extern char		wdir[]; /* must use extern because no dimension given */
 int			editing;
 int			erroutfd;
 int			messagesize;		/* negotiated in 9P version setup */
-int			globalautoindent;
+int			globalindent;
 int			dodollarsigns;
 char*		mtpt;
 

--- a/src/cmd/acme/look.c
+++ b/src/cmd/acme/look.c
@@ -797,9 +797,9 @@ openfile(Text *t, Expand *e)
 				runemove(rp, ow->incl[i], n);
 				winaddincl(w, rp, n);
 			}
-			w->autoindent = ow->autoindent;
+			w->indent = ow->indent;
 		}else
-			w->autoindent = globalautoindent;
+			w->indent = globalindent;
 		xfidlog(w, "new");
 	}
 	if(e->a1 == e->a0)

--- a/src/cmd/acme/util.c
+++ b/src/cmd/acme/util.c
@@ -107,7 +107,7 @@ errorwin1(Rune *dir, int ndir, Rune **incl, int nincl)
 		runemove(r, incl[i], n);
 		winaddincl(w, r, n);
 	}
-	w->autoindent = globalautoindent;
+	w->indent = globalindent;
 	return w;
 }
 

--- a/src/cmd/acme/wind.c
+++ b/src/cmd/acme/wind.c
@@ -80,10 +80,10 @@ wininit(Window *w, Window *clone, Rectangle r)
 	draw(screen, br, button, nil, button->r.min);
 	w->filemenu = TRUE;
 	w->maxlines = w->body.fr.maxlines;
-	w->autoindent = globalautoindent;
+	w->indent = globalindent;
 	if(clone){
 		w->dirty = clone->dirty;
-		w->autoindent = clone->autoindent;
+		w->indent = clone->indent;
 		textsetselect(&w->body, clone->body.q0, clone->body.q1);
 		winsettag(w);
 	}


### PR DESCRIPTION
When this mode is active, Acme emulates soft tabs by having the ⇥ key insert
$tabwidth space characters, and the ⌫ key delete as many space characters.

Without it, Acme only ever inserts single tab or space characters.

(based on code by https://github.com/neutralinsomniac)

![Tab-vs-Space](https://user-images.githubusercontent.com/24808322/88000605-554f8480-cafe-11ea-84b0-281f4355a4d8.jpeg)
