### PR TITLE
devdraw, libdraw: fix memory leaks by freeing getns() malloced string

### DIFF
--- a/src/cmd/devdraw/srv.c
+++ b/src/cmd/devdraw/srv.c
@@ -88,7 +88,7 @@ threadmain(int argc, char **argv)
 void
 gfx_started(void)
 {
-	char *addr;
+	char *ns, *addr;
 
 	if(srvname == nil) {
 		// Legacy mode: serving single client on pipes.
@@ -97,7 +97,11 @@ gfx_started(void)
 	}
 
 	// Server mode.
-	addr = smprint("unix!%s/%s", getns(), srvname);
+	if((ns = getns()) == nil)
+		sysfatal("out of memory");
+
+	addr = smprint("unix!%s/%s", ns, srvname);
+	free(ns);
 	if(addr == nil)
 		sysfatal("out of memory");
 

--- a/src/libdraw/drawclient.c
+++ b/src/libdraw/drawclient.c
@@ -23,7 +23,7 @@ int
 _displayconnect(Display *d)
 {
 	int pid, p[2], fd, nbuf, n;
-	char *wsysid, *addr, *id;
+	char *wsysid, *ns, *addr, *id;
 	uchar *buf;
 	Wsysmsg w;
 
@@ -40,7 +40,10 @@ _displayconnect(Display *d)
 			return -1;
 		}
 		*id++ = '\0';
-		addr = smprint("unix!%s/%s", getns(), wsysid);
+		if((ns = getns()) == nil)
+				return -1;
+		addr = smprint("unix!%s/%s", ns, wsysid);
+		free(ns);
 		if(addr == nil)
 			return -1;
 		fd = dial(addr, 0, 0, 0);


### PR DESCRIPTION
**getns()** returns a pointer to a malloced string. In some cases that malloced string was not freed causing memory leaks.