### PR TITLE
acme: support momentum scrolling on MacOS.

### DIFF
--- a/include/mouse.h
+++ b/include/mouse.h
@@ -1,7 +1,7 @@
 #ifndef _MOUSE_H_
 #define _MOUSE_H_ 1
 #if defined(__cplusplus)
-extern "C" { 
+extern "C" {
 #endif
 typedef struct	Menu Menu;
 typedef struct 	Mousectl Mousectl;
@@ -9,6 +9,7 @@ typedef struct 	Mousectl Mousectl;
 struct	Mouse
 {
 	int	buttons;	/* bit array: LMR=124 */
+	int scroll;
 	Point	xy;
 	ulong	msec;
 };

--- a/src/cmd/acme/acme.c
+++ b/src/cmd/acme/acme.c
@@ -620,14 +620,10 @@ mousethread(void *v)
 				goto Continue;
 			}
 			/* scroll buttons, wheels, etc. */
-			if(w != nil && (m.buttons & (8|16))){
-				if(m.buttons & 8)
-					but = Kscrolloneup;
-				else
-					but = Kscrollonedown;
+			if(w != nil && m.scroll != 0){
 				winlock(w, 'M');
 				t->eq0 = ~0;
-				texttype(t, but);
+				textmomentumscroll(t, m.scroll);
 				winunlock(w);
 				goto Continue;
 			}

--- a/src/cmd/acme/dat.h
+++ b/src/cmd/acme/dat.h
@@ -234,6 +234,7 @@ int		textselect3(Text*, uint*, uint*);
 void		textsetorigin(Text*, uint, int);
 void		textsetselect(Text*, uint, uint);
 void		textshow(Text*, uint, uint, int);
+void		textmomentumscroll(Text*, int);
 void		texttype(Text*, Rune);
 
 struct Window

--- a/src/cmd/acme/text.c
+++ b/src/cmd/acme/text.c
@@ -689,6 +689,32 @@ textcomplete(Text *t)
 }
 
 void
+textmomentumscroll(Text *t, int n)
+{
+	uint q0;
+
+	if(n == 0)
+		return;
+
+	if(t->what == Tag){
+		if(n<0)
+			texttype(t, Kscrolloneup);
+		else
+			texttype(t, Kscrollonedown);
+		return;
+	}
+
+	if(n < 0){
+		n = -n;
+		q0 = t->org+frcharofpt(&t->fr, Pt(t->fr.r.min.x, t->fr.r.min.y+n*t->fr.font->height));
+		textsetorigin(t, q0, TRUE);
+	}else{
+		q0 = textbacknl(t, t->org, n);
+		textsetorigin(t, q0, TRUE);
+	}
+}
+
+void
 texttype(Text *t, Rune r)
 {
 	uint q0, q1;

--- a/src/cmd/devdraw/devdraw.h
+++ b/src/cmd/devdraw/devdraw.h
@@ -200,7 +200,7 @@ struct DScreen
 void	gfx_abortcompose(Client*);
 void	gfx_keystroke(Client*, int);
 void	gfx_main(void);
-void	gfx_mousetrack(Client*, int, int, int, uint);
+void	gfx_mousetrack(Client*, int, int, int, int, uint);
 void	gfx_replacescreenimage(Client*, Memimage*);
 void	gfx_mouseresized(Client*);
 void	gfx_started(void);

--- a/src/cmd/devdraw/mac-screen.m
+++ b/src/cmd/devdraw/mac-screen.m
@@ -602,9 +602,9 @@ rpc_resizewindow(Client *c, Rectangle r)
 
 	s = [e scrollingDeltaY];
 	if(s > 0)
-		[self sendmouse:8];
+		[self sendmouse:8 by:s];
 	else if (s < 0)
-		[self sendmouse:16];
+		[self sendmouse:16 by:s];
 }
 
 - (void)keyDown:(NSEvent*)e
@@ -694,15 +694,29 @@ rpc_resizewindow(Client *c, Rectangle r)
 		m = [e modifierFlags];
 		if(m & NSEventModifierFlagOption){
 			gfx_abortcompose(self.client);
-			b = 2;
-		}else
-		if(m & NSEventModifierFlagCommand)
+			if(m & NSEventModifierFlagControl){
+				[self sendmouse:2];
+				b = 1;
+			}else
+				b = 2;
+		}else if(m & NSEventModifierFlagCommand)
 			b = 4;
+		else if(m & NSEventModifierFlagControl)
+			b = 8;
+	}else if(b == 4){
+		m = [e modifierFlags];
+		if(m & NSEventModifierFlagCommand)
+			b = 8;
 	}
 	[self sendmouse:b];
 }
 
 - (void)sendmouse:(NSUInteger)b
+{
+	[self sendmouse:b by:0];
+}
+
+- (void)sendmouse:(NSUInteger)b by:(NSUInteger)s
 {
 	NSPoint p;
 
@@ -710,7 +724,7 @@ rpc_resizewindow(Client *c, Rectangle r)
 		[self.window mouseLocationOutsideOfEventStream]];
 	p.y = Dy(self.client->mouserect) - p.y;
 	// LOG(@"(%g, %g) <- sendmouse(%d)", p.x, p.y, (uint)b);
-	gfx_mousetrack(self.client, p.x, p.y, b, msec());
+	gfx_mousetrack(self.client, p.x, p.y, b, s, msec());
 	if(b && _lastInputRect.size.width && _lastInputRect.size.height)
 		[self resetLastInputRect];
 }

--- a/src/cmd/devdraw/srv.c
+++ b/src/cmd/devdraw/srv.c
@@ -416,11 +416,11 @@ matchmouse(Client *c)
 void
 gfx_mouseresized(Client *c)
 {
-	gfx_mousetrack(c, -1, -1, -1, -1);
+	gfx_mousetrack(c, -1, -1, -1, 0, -1);
 }
 
 void
-gfx_mousetrack(Client *c, int x, int y, int b, uint ms)
+gfx_mousetrack(Client *c, int x, int y, int b, int s, uint ms)
 {
 	Mouse *m;
 
@@ -456,6 +456,7 @@ gfx_mousetrack(Client *c, int x, int y, int b, uint ms)
 		m->xy.x = x;
 		m->xy.y = y;
 		m->buttons = b;
+		m->scroll = s;
 		m->msec = ms;
 
 		c->mouse.m[c->mouse.wi] = *m;

--- a/src/cmd/devdraw/x11-screen.c
+++ b/src/cmd/devdraw/x11-screen.c
@@ -401,7 +401,7 @@ runxevent(XEvent *xev)
 	case MotionNotify:
 		if(_xtoplan9mouse(w, xev, &m) < 0)
 			return;
-		gfx_mousetrack(w->client, m.xy.x, m.xy.y, m.buttons|_x.kbuttons, m.msec);
+		gfx_mousetrack(w->client, m.xy.x, m.xy.y, m.buttons|_x.kbuttons, 0, m.msec);
 		break;
 
 	case KeyRelease:
@@ -446,7 +446,7 @@ runxevent(XEvent *xev)
 					_x.kbuttons |= 2;
 				if(c & Mod1Mask)
 					_x.kbuttons |= 4;
-				gfx_mousetrack(w->client, m.xy.x, m.xy.y, m.buttons|_x.kbuttons, m.msec);
+				gfx_mousetrack(w->client, m.xy.x, m.xy.y, m.buttons|_x.kbuttons, 0, m.msec);
 				break;
 			}
 		}

--- a/src/libdraw/drawfcall.c
+++ b/src/libdraw/drawfcall.c
@@ -61,7 +61,7 @@ sizeW2M(Wsysmsg *m)
 	case Rresize:
 		return 4+1+1;
 	case Rrdmouse:
-		return 4+1+1+4+4+4+4+1;
+		return 4+1+1+4+4+4+4+4+1;
 	case Tbouncemouse:
 		return 4+1+1+4+4+4;
 	case Tmoveto:
@@ -137,8 +137,9 @@ convW2M(Wsysmsg *m, uchar *p, uint n)
 		PUT(p+6, m->mouse.xy.x);
 		PUT(p+10, m->mouse.xy.y);
 		PUT(p+14, m->mouse.buttons);
-		PUT(p+18, m->mouse.msec);
-		p[19] = m->resized;
+		PUT(p+18, m->mouse.scroll);
+		PUT(p+22, m->mouse.msec);
+		p[23] = m->resized;
 		break;
 	case Tbouncemouse:
 		PUT(p+6, m->mouse.xy.x);
@@ -245,8 +246,9 @@ convM2W(uchar *p, uint n, Wsysmsg *m)
 		GET(p+6, m->mouse.xy.x);
 		GET(p+10, m->mouse.xy.y);
 		GET(p+14, m->mouse.buttons);
-		GET(p+18, m->mouse.msec);
-		m->resized = p[19];
+		GET(p+18, m->mouse.scroll);
+		GET(p+22, m->mouse.msec);
+		m->resized = p[23];
 		break;
 	case Tbouncemouse:
 		GET(p+6, m->mouse.xy.x);
@@ -347,9 +349,9 @@ drawfcallfmt(Fmt *fmt)
 	case Trdmouse:
 		return fmtprint(fmt, "Trdmouse");
 	case Rrdmouse:
-		return fmtprint(fmt, "Rrdmouse x=%d y=%d buttons=%d msec=%d resized=%d",
+		return fmtprint(fmt, "Rrdmouse x=%d y=%d buttons=%d scroll=%d msec=%d resized=%d",
 			m->mouse.xy.x, m->mouse.xy.y,
-			m->mouse.buttons, m->mouse.msec, m->resized);
+			m->mouse.buttons, m->mouse.scroll, m->mouse.msec, m->resized);
 	case Tbouncemouse:
 		return fmtprint(fmt, "Tbouncemouse x=%d y=%d buttons=%d",
 			m->mouse.xy.x, m->mouse.xy.y, m->mouse.buttons);


### PR DESCRIPTION
Inertial/momentum scrolling, in which the scrolling motion of an object continues in a decaying fashion after release of the touch, simulating the appearance of an object with inertia.

The implementation is mostly based on changes found in https://github.com/mariusae/plan9port.