### PR TITLE
acme: add threadmaybackground

### DIFF
--- a/src/cmd/acme/acme.c
+++ b/src/cmd/acme/acme.c
@@ -57,6 +57,12 @@ derror(Display *d, char *errorstr)
 	error(errorstr);
 }
 
+int
+threadmaybackground(void)
+{
+	return 1;
+}
+
 void
 threadmain(int argc, char *argv[])
 {


### PR DESCRIPTION
Without `threadmaybackground` acme will remain a white window when
started from a hotkey daemon such as skhd like this:

/usr/local/plan9/bin/9.rc acme -c3

This is what it looks like *without* `threadmaybackground`:

<img width="1080" alt="Screenshot 2021-02-08 at 23 07 31" src="https://user-images.githubusercontent.com/24808322/107288377-a657a380-6a63-11eb-888d-c8a87938b471.png">

With `threadmaybackground`:

<img width="1080" alt="Screenshot 2021-02-08 at 23 08 40" src="https://user-images.githubusercontent.com/24808322/107288406-b2dbfc00-6a63-11eb-9db0-cd6ca979fa57.png">
